### PR TITLE
Fixed wrong anchor in condition.

### DIFF
--- a/bptc.txt
+++ b/bptc.txt
@@ -460,7 +460,7 @@ block is:
       \textrm{IB} \times (x + 4\times y) - 1, & \textrm{NS} = 1,\ 0 < x + 4\times y \\
       \textrm{IB} \times (x + 4\times y) - 1, & \textrm{NS} = 2,\ 0 < x + 4\times y \leq \textrm{anchor}_2[\mathit{part}] \\
       \textrm{IB} \times (x + 4\times y) - 2, & \textrm{NS} = 2,\ \textrm{anchor}_2[\mathit{part}] < x + 4\times y \\
-      \textrm{IB} \times (x + 4\times y) - 1, & \textrm{NS} = 3,\ 0 < x + 4\times y \leq \textrm{anchor}_{3,2}[\mathit{part}],\ x + 4\times y \leq \textrm{anchor}_{3,2}[\mathit{part}]\\
+      \textrm{IB} \times (x + 4\times y) - 1, & \textrm{NS} = 3,\ 0 < x + 4\times y \leq \textrm{anchor}_{3,2}[\mathit{part}],\ x + 4\times y \leq \textrm{anchor}_{3,3}[\mathit{part}]\\
       \textrm{IB} \times (x + 4\times y) - 3, & \textrm{NS} = 3,\ x + 4\times y > \textrm{anchor}_{3,2}[\mathit{part}],\ x + 4\times y > \textrm{anchor}_{3,3}[\mathit{part}] \\
       \textrm{IB} \times (x + 4\times y) - 2, & \textrm{NS} = 3,\ \textrm{otherwise} \\
   \end{cases} \\


### PR DESCRIPTION
The last condition was redundant, and didn't make much sense. Bit addressing should change past each anchor index. For clarity it might make sense to instead write <=min(anchor_32,anchor_33) and <=max(anchor_32,anchor_33) for the case below.

Disclaimer: I struggle a little with understanding the anchor indices description, so please carefully double check this pr.
